### PR TITLE
group k: new pipeline jobs of group k are set to required

### DIFF
--- a/assets/data_ws2024.yaml
+++ b/assets/data_ws2024.yaml
@@ -291,6 +291,8 @@ repositories:
       - Spectral Linter
       - YAMLLint
       - Build and Package Application
+      - Build and Test with Docker Compose
+      - Build and Push Docker Image
   - name: group-k-transactions
     service: transactions
     teams:
@@ -303,6 +305,8 @@ repositories:
       - Spectral Linter
       - YAMLLint
       - Build and Package Application
+      - Build and Test with Docker Compose
+      - Build and Push Docker Image
   - name: group-l-accounts
     service: accounts
     teams:


### PR DESCRIPTION
The following new jobs have been integrated into the pipelines for the account and transaction services of Group K:
- Build and Test with Docker Compose
- Build and Push Docker Image
This pull request ensures that these jobs are set as required in their respective pipelines.
No related issue has been created for this change.

